### PR TITLE
Fix attribute name

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Example payload:
 ```json
 {
   "batteryCharge": 99,
-  "batteryVolage": 4.161,
+  "batteryVoltage": 4.161,
   "batteryCurrent": -0.427,
   "batteryTemperature": 47,
   "batteryStatus": "NORMAL",

--- a/pijuicemqtt.py
+++ b/pijuicemqtt.py
@@ -154,7 +154,7 @@ def publish_pijuice():
         status = pijuice.status.GetStatus()["data"]
         pijuice_status = {
             "batteryCharge": pijuice.status.GetChargeLevel()["data"],
-            "batteryVolage": pijuice.status.GetBatteryVoltage()["data"] / 1000,
+            "batteryVoltage": pijuice.status.GetBatteryVoltage()["data"] / 1000,
             "batteryCurrent": pijuice.status.GetBatteryCurrent()["data"] / 1000,
             "batteryTemperature": pijuice.status.GetBatteryTemperature()["data"],
             "batteryStatus": status["battery"],


### PR DESCRIPTION
There is an error in the attribute name related to the battery voltage.

The current name is "batteryVolage" instead of "batteryVoltage".