### PR TITLE
Add "expire_after" and "publish_online_status" attributes

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -9,7 +9,9 @@ mqtt:
 homeassistant:
   topic: homeassistant  # MQTT Autodiscovery root topic
   sensor: true  # Publish autodiscovery for PiJuice sensor
+  expire_after: 90 # If set, it defines the number of seconds after the sensor’s state expires, if it’s not updated. After expiry, the sensor’s state becomes unavailable
 
 publish_period: 30  # How long to wait between publishing information
+publish_online_status: true # Indicate if a availability message must be systematically published
 #hostname: myrpi  # Identifier for this Raspberry Pi, defaults to the hostname 
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -12,6 +12,6 @@ homeassistant:
   expire_after: 90 # If set, it defines the number of seconds after the sensor’s state expires, if it’s not updated. After expiry, the sensor’s state becomes unavailable
 
 publish_period: 30  # How long to wait between publishing information
-publish_online_status: true # Indicate if a availability message must be systematically published
+publish_online_status: true # Indicate if an availability message must be systematically published
 #hostname: myrpi  # Identifier for this Raspberry Pi, defaults to the hostname 
 

--- a/pijuicemqtt.py
+++ b/pijuicemqtt.py
@@ -138,7 +138,7 @@ def mqtt_on_connect(client, userdata, flags, rc):
             retain=True,
         )
 
-        # Battery Temperature sensor
+        # Battery Status sensor
         payload = {
             "name": f"{config['hostname']} PiJuice BatteryStatus",
             "unique_id": f"{SERVICE_NAME}-{config['hostname']}-batteryStatus",

--- a/pijuicemqtt.py
+++ b/pijuicemqtt.py
@@ -121,6 +121,37 @@ def mqtt_on_connect(client, userdata, flags, rc):
             retain=True,
         )
 
+        # Battery Temperature sensor
+        payload = {
+            "name": f"{config['hostname']} PiJuice BatteryTemperature",
+            "unique_id": f"{SERVICE_NAME}-{config['hostname']}-batteryTemperature",
+            "value_template": "{{ value_json.batteryTemperature }}",
+            "device_class": "temperature",
+            "unit_of_measurement": "°C",
+            "enabled_by_default": False,
+            "entity_category": "diagnostic",
+        }
+        client.publish(
+            f"{config['homeassistant']['topic']}/sensor/{SERVICE_NAME}-{config['hostname']}/batteryTemperature/config",
+            dumps({**base_payload, **payload}),
+            qos=1,
+            retain=True,
+        )
+
+        # Battery Temperature sensor
+        payload = {
+            "name": f"{config['hostname']} PiJuice BatteryStatus",
+            "unique_id": f"{SERVICE_NAME}-{config['hostname']}-batteryStatus",
+            "value_template": "{{ value_json.batteryStatus }}",
+            "enabled_by_default": False,
+            "entity_category": "diagnostic",
+        }
+        client.publish(
+            f"{config['homeassistant']['topic']}/sensor/{SERVICE_NAME}-{config['hostname']}/batteryStatus/config",
+            dumps({**base_payload, **payload}),
+            qos=1,
+            retain=True,
+        )
 
 def on_exit(signum, frame):
     """

--- a/pijuicemqtt.py
+++ b/pijuicemqtt.py
@@ -90,6 +90,10 @@ def mqtt_on_connect(client, userdata, flags, rc):
                 "manufacturer": "PiSupply",
             },
         }
+
+        if "expire_after" in config["homeassistant"]:
+            base_payload["expire_after"] = int(config["homeassistant"]["expire_after"])
+
         # Battery charge percentage
         payload = {
             "name": f"{config['hostname']} PiJuice Battery",
@@ -182,6 +186,15 @@ def publish_pijuice():
     timer_thread.start()
 
     try:
+
+        if "publish_online_status" in config and config["publish_online_status"]:
+            client.publish(
+                f"{SERVICE_NAME}/{config['hostname']}/service",
+                payload="online",
+                qos=1,
+                retain=True,
+            )
+
         status = pijuice.status.GetStatus()["data"]
         pijuice_status = {
             "batteryCharge": pijuice.status.GetChargeLevel()["data"],


### PR DESCRIPTION
**Add "expire_after" attribute in configuration.** If set, it defines the number of seconds after the sensor’s state expires, if it’s not updated. After expiry, the sensor’s state becomes unavailable.

**Add "publish_online_status" attribute in configuration.** Indicate if a availability message must be systematically published.

Don't know why but sometimes my RPi crashed suddently. With these optionnal options, I can see the correct information in Home Assistant.